### PR TITLE
fix(snake): Improper passing of props causing incorrect AI highlight of both sides

### DIFF
--- a/src/components/Snake/Snake.tsx
+++ b/src/components/Snake/Snake.tsx
@@ -382,7 +382,12 @@ function Snake({
           debug={debug}
           onPieceClick={debug ? (piece) => toggleBreakpoint(piece) : undefined}
           highlightPiece={debug ? pieceIsBreakpoint : undefined}
-          highlightSide={highlightSide}
+          highlightSide={
+            (highlightSide === "left" && index === 0) ||
+            (highlightSide === "right" && index === segments.length - 1)
+              ? highlightSide
+              : undefined
+          }
           isAnchoredOnDouble={segmentIsAnchoredOnDouble(index)}
         />
       ))}


### PR DESCRIPTION
highlightSide was passed to all snake segments improperly...

this was not apparent as an issue because the edge case is very rare, the segment on the opposite side of the snake of the segment that has the playable side of the AI move had to both have a single piece and a piece where the piece of the AI move could also played on!